### PR TITLE
refactor: move semantic release config to dedicated file

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -1,0 +1,23 @@
+---
+branch: master
+tagFormat: '${version}'
+analyzeCommits:
+  path: '@semantic-release/commit-analyzer'
+  preset: peakfijn
+  releaseRules: release-rules-peakfijn
+generateNotes:
+  path: '@semantic-release/release-notes-generator'
+  preset: peakfijn
+verifyConditions:
+  - '@semantic-release/changelog'
+  - '@semantic-release/npm'
+  - semantic-release-git-branches
+prepare:
+  - '@semantic-release/changelog'
+  - '@semantic-release/npm'
+  - path: semantic-release-git-branches
+    branchMerges: [develop, master]
+    message: |-
+      release: create new version ${nextRelease.version} [skip ci]
+
+      ${nextRelease.notes}

--- a/package.json
+++ b/package.json
@@ -42,38 +42,6 @@
   "eslintConfig": {
     "extends": "react-app"
   },
-  "release": {
-    "branch": "master",
-    "tagFormat": "${version}",
-    "analyzeCommits": {
-      "path": "@semantic-release/commit-analyzer",
-      "preset": "peakfijn",
-      "releaseRules": "release-rules-peakfijn"
-    },
-    "generateNotes": [
-      {
-        "path": "@semantic-release/release-notes-generator",
-        "preset": "peakfijn"
-      }
-    ],
-    "verifyConditions": [
-      "@semantic-release/changelog",
-      "@semantic-release/npm",
-      "semantic-release-git-branches"
-    ],
-    "prepare": [
-      "@semantic-release/changelog",
-      "@semantic-release/npm",
-      {
-        "path": "semantic-release-git-branches",
-        "message": "release: create new version ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}",
-        "branchMerges": [
-          "develop",
-          "master"
-        ]
-      }
-    ]
-  },
   "greenkeeper": {
     "commitMessages": {
       "initialBadge": "documentation: add greenkeeper badge",


### PR DESCRIPTION
It’s too big and litters the `package.json` too much to justify merging it there.

### Linked issue
_none, part of initial project setup_
