### PR TITLE
Use absolute imports

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+NODE_PATH=./

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-import './providers/react';
-import './providers/service-worker';
+import 'src/providers/react';
+import 'src/providers/service-worker';

--- a/src/pages/app/App.js
+++ b/src/pages/app/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import logo from '../../assets/logo.svg';
+import logo from 'src/assets/logo.svg';
 import './App.css';
 
 class App extends Component {

--- a/src/providers/react.js
+++ b/src/providers/react.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render } from 'react-dom';
 
-import App from '../pages/app';
+import App from 'src/pages/app';
 
 render(<App />, document.getElementById('root'));

--- a/src/providers/service-worker.js
+++ b/src/providers/service-worker.js
@@ -1,4 +1,4 @@
-import * as serviceWorker from '../sw';
+import * as serviceWorker from 'src/sw';
 
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.


### PR DESCRIPTION
### Linked issue
_none, part of initial setup_

### Additional context
Personally, I don't like having to think about how many `../` I need to use to import something. Having absolute imports make these things cleaner and predictable. Setting `NODE_PATH` to project root, instead of `./src` is intentional. 

Having `./src` makes it visually less distinctive compared to normal plugins, e.g.

```
import someUtil from 'library/subfolder`;
import somePage from `pages/subfolder`;
```

Adding the `src` makes it a bit more distinctive, e.g.

```
import someUtil from 'library/subfolder`;
import somePage from `src/pages/subfolder`;
```

I'm also kind of 99.9% positive that there won't, or at least shouldn't, be a library called `src`. So name collision is out of the question.
