### PR TITLE
fix: allow package scope for greenkeeper only

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,11 @@
 	"commitlint": {
 		"extends": [
 			"@peakfijn/config-commitlint"
-		]
+		],
+		"rules": {
+			"scope-empty": [0],
+			"scope-enum": [2, "always", ["package"]]
+		}
 	},
 	"eslintConfig": {
 		"extends": "react-app",


### PR DESCRIPTION
This should not be used. All commits including this scope must be squashed.

It's only there since Greenkeeper doesn't allow changing this message (yet).