### PR TITLE
fix: align user description horizontally with small text

### DIFF
--- a/src/molecules/user/elements.js
+++ b/src/molecules/user/elements.js
@@ -45,6 +45,7 @@ export const UserDescription = styled.p`
 	display: flex;
 	flex: 1;
 	align-items: flex-start;
+	justify-content: center;
 	margin: 0;
 	padding: 0.5rem;
 	width: 100%;


### PR DESCRIPTION
### Linked issue
Aligns short user descriptions horizontally.
