### PR TITLE
fix: prefix github username environment variable

### DIFF
--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -3,7 +3,7 @@ import { createInstance } from 'react-async';
 /**
  * The GitHub username to fetch information from.
  */
-export const username = process.env.GITHUB_USERNAME || 'byCedric';
+export const username = process.env.REACT_APP_GITHUB_USERNAME || 'byCedric';
 
 /**
  * Fetch the user information from the GitHub API.


### PR DESCRIPTION
### Linked issue
Without this, the variable is never loaded during build, and will always fall back to `byCedric` otherwise.
