### PR TITLE
fix: avatar atom default props overwriting original proptypes

### DIFF
--- a/src/atoms/avatar/avatar.js
+++ b/src/atoms/avatar/avatar.js
@@ -23,6 +23,6 @@ AvatarAtom.propTypes = {
 	title: PropTypes.string,
 };
 
-AvatarAtom.propTypes = {
+AvatarAtom.defaultProps = {
 	title: undefined,
 };


### PR DESCRIPTION
### Linked issue
Fixed a typo for default props definitions in the Avatar atom component.