### PR TITLE
pipeline: disable windows builds due to issues with env vars

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,11 @@
 language: node_js
 node_js:
   - node
-  - 8
+  - lts/*
 
 os:
   - linux
   - osx
-  - windows
 
 cache:
   directories:
@@ -32,11 +31,11 @@ deploy:
       - npx semantic-release --dry-run --branch develop
     on:
       branch: develop
-      node: 8
+      node: lts/*
   - provider: script
     skip_cleanup: true
     script:
       - npx semantic-release
     on:
       branch: master
-      node: 8
+      node: lts/*


### PR DESCRIPTION
### Linked issue
Disable Windows builds until the blocking issues are resolved by Travis.

### Additional context
See https://travis-ci.community/t/windows-instances-hanging-before-install/250/6