### PR TITLE
pipeline: limit release scripts to only linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ deploy:
     script:
       - npx semantic-release --dry-run --branch develop
     on:
+      condition: $TRAVIS_OS_NAME = linux
       branch: develop
       node: lts/*
   - provider: script
@@ -37,5 +38,6 @@ deploy:
     script:
       - npx semantic-release
     on:
+      condition: $TRAVIS_OS_NAME = linux
       branch: master
       node: lts/*


### PR DESCRIPTION
### Linked issue
We don't want semantic releases to spam on all platforms when making new releases.