### PR TITLE
pipeline: move context to build folder to work around unexpected behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,9 @@ deploy:
     script: >
       npx semantic-release --dry-run --branch develop &&
       npm run build &&
-      npx now ./build -t $NOW_TOKEN -T personal -A ./now.staging.json &&
-      npx now alias -A ./now.staging.json
+      cd build &&
+      npx now -t $NOW_TOKEN -T personal -A ../now.staging.json &&
+      npx now alias -A ../now.staging.json
     on:
       condition: $TRAVIS_OS_NAME = linux
       branch: develop


### PR DESCRIPTION
### Linked issue
Without this Now is ignoring most of the config and deploys it under another project.
