### PR TITLE
chore: enable default test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 	"scripts": {
 		"start": "react-scripts start",
 		"build": "react-scripts build",
-		"test": "echo 'No tests specified (yet)'; exit 0",
+		"test": "react-scripts test",
 		"eject": "react-scripts eject"
 	},
 	"dependencies": {


### PR DESCRIPTION
### Linked issue
Since we have one test now, we can enable this again.