### PR TITLE
fix: center user full name for multiple lines

### DIFF
--- a/src/molecules/user/elements.js
+++ b/src/molecules/user/elements.js
@@ -31,6 +31,7 @@ export const UserName = styled.h1`
 	flex: 0;
 	margin: 0;
 	padding: 0.5rem;
+	text-align: center;
 	line-height: 1.5;
 	color: #24292e;
 	font-size: 2em;


### PR DESCRIPTION
### Linked issue
Fixes user's full name not being centered when broken over multiple lines.