### PR TITLE
chore: integrate styled components macro for easy debugging

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
 		"not ie <= 11",
 		"not op_mini all"
 	],
+	"babelMacros": {
+		"styledComponents": {
+			"fileName": false
+		}
+	},
 	"commitlint": {
 		"extends": [
 			"@peakfijn/config-commitlint"

--- a/src/atoms/avatar/elements.js
+++ b/src/atoms/avatar/elements.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 /**
  * The avatar container "masks" the underlying image and makes it circular.

--- a/src/atoms/highlight/elements.js
+++ b/src/atoms/highlight/elements.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 /**
  * The highlight container groups the content using a paragraph.

--- a/src/molecules/user/elements.js
+++ b/src/molecules/user/elements.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 /**
  * The user container creates a vertical-directed flexbox.

--- a/src/pages/app/elements.js
+++ b/src/pages/app/elements.js
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 /**
  * The app container wraps the content and centers it both horizontally and vertically.


### PR DESCRIPTION
### Linked issue
This introduces styled component macros. This enables the babel plugin of styled components, for zero configuration projects like CRA.
