### PR TITLE
Fix/GitHub keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 		"@semantic-release/changelog": "^3.0.0",
 		"codecov": "^3.1.0",
 		"conventional-changelog-peakfijn": "^0.8.0",
+		"jest-chain": "^1.0.4",
 		"now": "^11.4.6",
 		"react-scripts": "2.0.5",
 		"release-rules-peakfijn": "^0.8.0",

--- a/src/providers/github.js
+++ b/src/providers/github.js
@@ -33,5 +33,5 @@ export const AsyncUser = createInstance({ promiseFn: fetchUser });
  * @return {string[]}
  */
 export const findKeywords = (text) => (
-	(text || '').match(/[@#]([a-z0-9]+)/gi).map(value => value.substr(1))
+	((text || '').match(/[@#]([a-z0-9]+)/gi) || []).map(value => value.substr(1))
 );

--- a/src/providers/github.test.js
+++ b/src/providers/github.test.js
@@ -1,0 +1,30 @@
+import { findKeywords } from './github';
+
+describe('providers/github', () => {
+	describe('findKeywords', () => {
+		it('finds mentions from text', () => {
+			expect(findKeywords('Something something @github something @bycedric.'))
+				.toHaveLength(2)
+				.toContain('github')
+				.toContain('bycedric');
+		});
+
+		it('finds hastags from text', () => {
+			expect(findKeywords('Something maintainer #project something #other.'))
+				.toHaveLength(2)
+				.toContain('project')
+				.toContain('other');
+		});
+
+		it('finds mention and hastag from text', () => {
+			expect(findKeywords('Something @github something maintainer #project.'))
+				.toHaveLength(2)
+				.toContain('github')
+				.toContain('project');
+		});
+
+		it('returns empty array when nothing is found', () => {
+			expect(findKeywords('Something something something.')).toHaveLength(0);
+		});
+	});
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import 'jest-chain';


### PR DESCRIPTION
### Linked issue
I've noticed some issues with `findKeywords` when no keywords were found. This should fix it.
