### PR TITLE
Upgrade travis with auto-release and security checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,7 @@ node_js:
 os:
   - linux
   - osx
-cache:
-  directories:
-    - node_modules
-install:
-  - npm install
+cache: npm
 script:
   - npx commitlint-travis
   - npx stylelint './src/**/*.js'

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ script:
   - npx stylelint './src/**/*.js'
   - npx eslint ./src
   - npx react-scripts test --coverage
+  - npm audit
 after_success:
   - npx codecov
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 ---
 language: node_js
 node_js:
-  - node
+  - 11
+  - 10
+  - 8
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,11 @@ script:
   - npx react-scripts test --coverage
 after_success:
   - npx codecov
+deploy:
+  - provider: script
+    skip_cleanup: true
+    script: npx semantic-release --dry-run --branch develop
+    on:
+      node: 11
+      branch: develop
+      condition: $TRAVIS_OS_NAME = linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,10 @@ deploy:
       node: 11
       branch: develop
       condition: $TRAVIS_OS_NAME = linux
+  - provider: script
+    skip_cleanup: true
+    script: npx semantic-release
+    on:
+      node: 11
+      branch: master
+      condition: $TRAVIS_OS_NAME = linux


### PR DESCRIPTION
### Linked issue
Because of the latest changes related to Now, we can now perform security checks in the pipeline with the lockfile. I also added semantic release scripts to test what version will be next with the current state of develop. When this is (manually) merged to master, it will perform the release automatically.

### Additional context
I see the GitHub fetch tests are failing in Node 8, I'll replace this with whatwg fetch (universal fetch) in another PR.
