### PR TITLE
pipeline: limit node versions because of unexpected fetch behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - 11
   - 10
-  - 8
 os:
   - linux
   - osx


### PR DESCRIPTION
### Linked issue
Apparently, Node 8 appears to have some unexpected behavior with mocking fetch for testing. 
